### PR TITLE
docs: add project README with OctoAcme process summary

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,36 @@
+# OctoAcme Project Management Docs
+
+## Overview
+
+The OctoAcme project management framework ensures that projects move smoothly from inception to delivery through a repeatable, documented lifecycle. Initiatives begin with a validated statement of need, measurable success metrics, stakeholder alignment, and a one-pager artifact that guides go/no-go decisions. Planning transforms approved ideas into actionable backlogs with clear acceptance criteria, estimates, a Definition of Done, and risk registers—centralized within versioned docs and visible on the project board to keep the team aligned.
+
+Execution relies on disciplined pull request practices, automated CI checks for code and security, and a Kanban/Scrum workflow that tracks work from Backlog to Done. Roles are explicit and collaborative: Product Managers set outcomes and priorities, Project Managers coordinate delivery and risk, Developers build and test, and QA validates requirements and releases. Regular routines (standups, delivery syncs, stakeholder updates) plus artifact templates provide cadence and support consistent, timely communication and escalation.
+
+Quality and learning are embedded throughout. Every project has well-defined acceptance criteria, automated and manual QA, and checklists for releases, rollbacks, and incident responses. Retrospectives after milestones or incidents yield actionable improvements, which feed directly back into the backlog—driving a culture of transparency, psychological safety, and continuous improvement.
+
+Centralizing these practices in evolving, living documentation empowers teams to standardize workflows, accelerate onboarding, and avoid knowledge silos. This README is the entry point to our approved project management knowledge base.
+
+## Quick process summary
+
+A short, high-level view of the OctoAcme project management lifecycle (use the linked docs for details):
+
+- Initiate — Capture the problem, success metrics, stakeholders, and a one-pager to validate investment and align decision-makers.
+- Plan — Translate approved work into a prioritized backlog with acceptance criteria, estimates, Definition of Done, and a risk register.
+- Execute — Deliver work via short, visible increments (Kanban/Scrum), disciplined pull requests, and automated CI checks.
+- Release & Operate — Use release checklists, automated deployments, rollout/rollback plans, and runbooks for incidents.
+- Review & Improve — Hold retrospectives, capture action items, and feed improvements back into the backlog to close learning loops.
+
+These steps are described in detail in the process documents below and are intended to be living practices: update them as teams validate better ways of working.
+
+## Process Documentation
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](./octoacme-roles-and-personas.md)
+
+Keep this README up to date as new practices are validated or new documents are added.


### PR DESCRIPTION
Adds README in docs/ with a brief overview of OctoAcme project management processes. Closes #2.